### PR TITLE
Update build_fproxy.sh to keep a compiled binary.

### DIFF
--- a/build_fproxy.sh
+++ b/build_fproxy.sh
@@ -13,6 +13,8 @@ function main {
   go build -tags netgo -o "$WORKDIR"/fproxy .
 
   docker build -f ./Dockerfile -t fproxy:latest "$WORKDIR"
+
+  cp "$WORKDIR"/fproxy .
 }
 
 main "$@"


### PR DESCRIPTION
Previously, it would build it in a temp folder, package it in a Docker
image, and then delete the temp folder. Now, we copy the binary out of
the temp folder to a local (already gitignored) file, in case it is
required.